### PR TITLE
remember image zoom

### DIFF
--- a/.cfg.example
+++ b/.cfg.example
@@ -38,6 +38,7 @@
   "editExplorerNotes": false,
   "imgContrast": "150",
   "imgBrightness": "75",
+  "defaultZoom": "70",
   "imageInvert": false,
   "imageColorMap": false,
   "importFiles": true,

--- a/client/src/components/ShowImage.vue
+++ b/client/src/components/ShowImage.vue
@@ -34,7 +34,6 @@ export default {
   },
   data() {
     return {
-      imageWidth: 70,
       contrast: 100,
       brightness: 100,
       options: {
@@ -125,9 +124,13 @@ export default {
         ],
       }
     },
+    imageWidth() {
+      return this.defaultZoom || 70
+    },
     ...mapGetters([
       'imageInvert',
       'imageColorMap',
+      'defaultZoom',
     ]),
   },
   mounted() {

--- a/client/src/components/WSOption.vue
+++ b/client/src/components/WSOption.vue
@@ -304,6 +304,15 @@ export default {
           },
         },
         {
+          label: 'Zoom',
+          field: 'defaultZoom',
+          type: types.SLIDER,
+          options: {
+            max: 100,
+            min: 0,
+          },
+        },
+        {
           label: 'Backup path',
           field: 'backupPath',
           type: types.TEXT,

--- a/client/src/components/field/Index.vue
+++ b/client/src/components/field/Index.vue
@@ -26,7 +26,7 @@
       <b-form-checkbox v-else-if="schema.type === types.BOOLEAN" v-model="temp"/>
       <b-form-tags v-else-if="schema.type === types.T_ARRAY" v-model="temp" :placeholder="schema.options.placeholder"/>
       <b-row v-else-if="schema.type === types.SLIDER">
-        <b-col sm="8"><b-form-input type="range" v-model="temp" min="0" max="200"/></b-col>
+        <b-col sm="8"><b-form-input type="range" v-model="temp" :min="schema.options.min || 0" :max="schema.options.max || 200"/></b-col>
         <b-col><code>{{temp}}%</code></b-col>
       </b-row>
     </b-col>

--- a/client/src/store/getters.js
+++ b/client/src/store/getters.js
@@ -25,6 +25,7 @@ const getters = {
   imageSpacing: (state) => state.app.explorerConfig.imageSpacing || 10,
   imageInvert: (state) => state.app.explorerConfig.imageInvert,
   imageColorMap: (state) => state.app.explorerConfig.imageColorMap,
+  defaultZoom: (state) => state.app.explorerConfig.defaultZoom,
   workspaceFontSize: (state) => state.app.config.workspaceFontSize,
   subFolderFontSize: (state) => state.app.config.subFolderFontSize,
   changePWDUri: (state) => state.app.config.changePWDUri,

--- a/default.cfg
+++ b/default.cfg
@@ -26,6 +26,7 @@
     "imageStorage: "ws",
     "imageInvert": true,
     "imageColorMap": true,
+    "defaultZoom": "70",
     "importFiles": true,
     "maxFileSize": 10
 }


### PR DESCRIPTION
## Store the default zoom setting in Workspaces
- Add a setting to the workspace to store the default zoom size for images in the single image view.
 
![image](https://user-images.githubusercontent.com/46847212/157761548-cf1ab0b6-f556-4779-927c-52e511cabff6.png)

- Add the setting to the Workspace UI settings in region Image:## General
![image](https://user-images.githubusercontent.com/46847212/157761578-82cdde8b-a0fa-4b27-b3b7-158c64133c2b.png)
