### PR TITLE
Feature/update calculation of statistics

### DIFF
--- a/app/Controllers/Http/ExplorerController.js
+++ b/app/Controllers/Http/ExplorerController.js
@@ -912,11 +912,6 @@ class ExplorerController {
 
     if (!folder) throw new Error('The "folder" parameter is needed');
 
-    if (!accessToFile(CONST_PATHS.root, folder)) {
-      logger.error(`ExplorerController.getSubfolders: Access denied for gettings subfolders for folder ${folder}`);
-      throw new Error(`Access denied`);
-    }
-
     // const files = await readdir(folder)
     //
     // for (let i = 0; i < files.length; ++i) {
@@ -927,7 +922,7 @@ class ExplorerController {
     //   }
     // }
 
-    return this.countSync(folder, 'root');
+    return this.countSync(path.join(CONST_PATHS.root, folder), folder);
   }
 
   /*

--- a/client/src/components/StatisticTable.vue
+++ b/client/src/components/StatisticTable.vue
@@ -37,10 +37,10 @@
               <span v-if="table[name2][name1].all > 0" class="clickable-text">
                 <a href="javascript:;" v-on:click="select(name1, name2)">
                   <span v-if="valuesView === 'absolute'">
-                    {{ exclude ? table[name2][name1].exclude : table[name2][name1].all }}
+                    {{ (table[name2][name1][exclude ? 'exclude' : 'all']).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") }}
                   </span>
                   <span v-if="valuesView === 'percentage'">
-                    {{ Math.round(table[name2][name1][exclude ? 'exclude' : 'all'] / sumFor(name2) * 100) }}%
+                    {{ (table[name2][name1][exclude ? 'exclude' : 'all'] / sumFor(name1) * 100).toFixed(1) }}%
                   </span>
                 </a>
               </span>
@@ -91,15 +91,13 @@ export default {
       })
     },
     sumFor(name) {
-      return Object.keys(this.table[name])
-        .map((n) => (this.exclude ? this.table[name][n].exclude : this.table[name][n].all))
-        .reduce((p, c) => c + p)
+      return Object.values(this.table)
+        .map((row) => row[name][this.exclude ? 'exclude' : 'all'])
+        .reduce((p, c) => c + p, 0)
     },
   },
   computed: {
     names() {
-      console.log(Object.keys(this.table)
-        .map((n) => n))
       return Object.keys(this.table)
         .map((n) => n)
     },


### PR DESCRIPTION

## Change the calculation of statistics
The accuracy is calculated based on the file name and not on the folder name. This needs to be changed. (See image example)
(We want to know how high the false reject rate is and not how high the AI results are distributed)
Please add one decimal place for percent #.#%
Please add a coma separator for thousand decimals
Double check if the Matched / Missmatched is calculated correctly. 