### PR TITLE
support Scientific Notation in GUI

### DIFF
--- a/client/src/components/TFOption.vue
+++ b/client/src/components/TFOption.vue
@@ -829,10 +829,16 @@ export default {
       if (!this.canEditConfigAIUI && this.editor) {
         this.data = this.editor.get()
       }
-      const data = {
+      let data = {
         ...this.fields,
         ...this.data,
       }
+      data = this.transformEachChild(data, (child) => {
+        if (!Number.isNaN(Number(child)) && typeof child === 'string') {
+          return Number(child)
+        }
+        return child
+      })
       const filePath = `${this.ws}/TFSettings.json`
       console.log(JSON.stringify(data, null, 2))
       await api.saveFile(filePath, JSON.stringify(data, null, 2))
@@ -840,6 +846,18 @@ export default {
     },
     onOpen() {
       this.loadFile()
+    },
+    transformEachChild(obj, callback) {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const k in obj) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (obj.hasOwnProperty(k) && obj[k] && typeof obj[k] === 'object') {
+          this.transformEachChild(obj[k], callback)
+        } else {
+          obj[k] = callback(obj[k]) // eslint-disable-line no-param-reassign
+        }
+      }
+      return obj
     },
   },
   computed: {

--- a/client/src/components/field/Index.vue
+++ b/client/src/components/field/Index.vue
@@ -119,12 +119,7 @@ export default {
   },
   methods: {
     handleInput(value) {
-      if (this.schema.type === types.NUMBER) {
-        // eslint-disable-next-line radix
-        this.temp = Number.parseFloat(value)
-      } else {
-        this.temp = value
-      }
+      this.temp = value
     },
     toggleAuto() {
       // const fallbackJson = this.schema.type === types.J_ARRAY ? new Array(this.schema.options?.schema?.length || 0).fill(0) : {}


### PR DESCRIPTION
### Current situation:
Numbers in scientific notation are not available in EjectX GUI.
eg:
```json
{
    "epsilon": 1e-10,
    ....
}
```
In the GUI the value is displayed, but cannot be modified.

### Desired Situation:
Support of this notation in EjectX GUI whenever it is present. (All float numbers)
It is regarded a feature which comes with json and is hard to work around.
A python json.dumps to write a json will always use this notation automatically and would have to be replaced afterward manually. 