### PR TITLE
Setting for Unclassified

### DIFF
--- a/.cfg.example
+++ b/.cfg.example
@@ -18,6 +18,7 @@
   "deleteDefaultFolder": "Deleted_files",
   "selectedPath": "Selected_new",
   "notSelectedPath": "Not_Selected",
+  "unclassifiedPath": "Unclassified",
   "forwardOnly": true,
   "buttonFontSize": "1rem",
   "titleFontSize": "1rem",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svtrain",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "private": true,
   "scripts": {
     "serve": "cross-env NODE_ENV=development vue-cli-service serve",

--- a/client/src/components/WSOption.vue
+++ b/client/src/components/WSOption.vue
@@ -192,6 +192,15 @@ export default {
             },
           },
           {
+            label: 'Unclassified path',
+            field: 'unclassifiedPath',
+            type: types.TEXT,
+            options: {
+              help: 'Folder name where the labeling starts. Reference for progress bar calculation',
+              default: 'Unclassified',
+            },
+          },
+          {
             label: 'Confirm Button',
             field: 'forwardLocation',
             type: types.SELECT,

--- a/client/src/components/WorkspaceFolder.vue
+++ b/client/src/components/WorkspaceFolder.vue
@@ -50,7 +50,7 @@
             class="option-progress-text"
             v-if="
               showSubFolderProgress &&
-              info.name.toLowerCase() !== 'unclassified' &&
+              info.name.toLowerCase() !== info.unclassifiedPath &&
               totalFiles > 0
             "
           >
@@ -63,17 +63,17 @@
             v-bind:class="{
               'opacity-0':
                 !(showSubFolderProgress || depth === 0) ||
-                info.name.toLowerCase() === 'unclassified' ||
+                info.name.toLowerCase() === info.unclassifiedPath ||
                 totalFiles <= 0,
               'cursor-pointer':
                 totalFiles > 0 &&
-                info.name.toLowerCase() !== 'unclassified' &&
+                info.name.toLowerCase() !== info.unclassifiedPath &&
                 (showSubFolderProgress || depth === 0),
             }"
             @click="
               !(
                 !(showSubFolderProgress || depth === 0) ||
-                info.name.toLowerCase() === 'unclassified' ||
+                info.name.toLowerCase() === info.unclassifiedPath ||
                 totalFiles <= 0
               ) && canViewStatistics
                 ? showStatistic()
@@ -428,9 +428,6 @@ export default {
           ...this.getSubFolderStatistics(currentSubFolder),
         }
         Object.entries(subFolderStats).forEach(([key, value]) => {
-          if (subFolderStats.path === '/Something4/test') {
-            console.log(key, value)
-          }
           if (!Number.isInteger(value)) return
           totalStats[key] = (totalStats[key] || 0) + value // eslint-disable-line no-param-reassign
         })

--- a/client/src/components/field/Index.vue
+++ b/client/src/components/field/Index.vue
@@ -85,6 +85,10 @@ export default {
   data() {
     let temp = this.value
     if (temp === null) {
+      if (this.schema.options.default !== undefined) {
+        temp = this.schema.options.default
+        this.$emit('input', temp)
+      }
       if (this.schema.type === types.JSON) {
         temp = {}
         this.$emit('input', temp)

--- a/config/ui.js
+++ b/config/ui.js
@@ -18,6 +18,7 @@ module.exports = {
   deleteDefaultFolder: 'Deleted_files',
   selectedPath: 'Selected_new',
   notSelectedPath: 'Not_Selected',
+  unclassifiedPath: 'Unclassified',
   forwardOnly: false,
   buttonFontSize: '1rem',
   titleFontSize: '1rem',

--- a/default.cfg
+++ b/default.cfg
@@ -15,6 +15,7 @@
     "deleteDefaultFolder": "Deleted_files",
     "selectedPath": "Selected_new",
     "notSelectedPath": "Not_Selected",
+    "unclassifiedPath": "Unclassified",
     "forwardOnly": true,
     "buttonFontSize": "1rem",
     "titleFontSize": "1rem",


### PR DESCRIPTION
Add a parameter unclassifiedFolderName to the .cfg settings.

Use the default "Unclassified" when the parameter is not set.

Add the corresponding unclassifiedFolderName to the UI labeling settings.


