### PR TITLE
adding the dropdown menu in the AI setting popup's n/w arch field

### DIFF
--- a/ui/src/components/TFOption.vue
+++ b/ui/src/components/TFOption.vue
@@ -357,74 +357,29 @@ export default {
             type: types.SELECT,
             options: {
               dataset: [
-                {
-                  value: 'net_CPCP',
-                  label: 'net_CPCP',
-                },
-                {
-                  value: 'net_CPCPCP',
-                  label: 'net_CPCPCP',
-                },
-                {
-                  value: 'net_CPCPCPCP',
-                  label: 'net_CPCPCPCP',
-                },
-                {
-                  value: 'net_CCPCCP',
-                  label: 'net_CCPCCP',
-                },
-                {
-                  value: 'net_CCPCCPCCP',
-                  label: 'net_CCPCCPCCP',
-                },
-                {
-                  value: 'net_CCPCCPCCPCCP',
-                  label: 'net_CCPCCPCCPCCP',
-                },
-                {
-                  value: 'VGG16',
-                  label: 'VGG16',
-                },
-                {
-                  value: 'InceptionV3',
-                  label: 'InceptionV3',
-                },
-                {
-                  value: 'MobileNetV2',
-                  label: 'MobileNetV2',
-                },
-                {
-                  value: 'EfficientNetB0',
-                  label: 'EfficientNetB0',
-                },
-                {
-                  value: 'EfficientNetB1',
-                  label: 'EfficientNetB1',
-                },
-                {
-                  value: 'EfficientNetB2',
-                  label: 'EfficientNetB2',
-                },
-                {
-                  value: 'EfficientNetB3',
-                  label: 'EfficientNetB3',
-                },
-                {
-                  value: 'EfficientNetB4',
-                  label: 'EfficientNetB4',
-                },
-                {
-                  value: 'EfficientNetB5',
-                  label: 'EfficientNetB5',
-                },
-                {
-                  value: 'EfficientNetB6',
-                  label: 'EfficientNetB6',
-                },
-                {
-                  value: 'EfficientNetB7',
-                  label: 'EfficientNetB7',
-                },
+                { value: 'VGG16', label: 'VGG16' },
+                { value: 'InceptionV3', label: 'InceptionV3' },
+                { value: 'MobileNetV2', label: 'MobileNetV2' },
+                { value: 'EfficientNetB0', label: 'EfficientNetB0' },
+                { value: 'EfficientNetB1', label: 'EfficientNetB1' },
+                { value: 'EfficientNetB2', label: 'EfficientNetB2' },
+                { value: 'EfficientNetB3', label: 'EfficientNetB3' },
+                { value: 'EfficientNetB4', label: 'EfficientNetB4' },
+                { value: 'EfficientNetB5', label: 'EfficientNetB5' },
+                { value: 'EfficientNetB6', label: 'EfficientNetB6' },
+                { value: 'EfficientNetB7', label: 'EfficientNetB7' },
+                { value: 'net_CPCP', label: 'net_CPCP' },
+                { value: 'net_CPCPCP', label: 'net_CPCPCP' },
+                { value: 'net_CPCPCPCP', label: 'net_CPCPCPCP' },
+                { value: 'net_CCPCCP', label: 'net_CCPCCP' },
+                { value: 'net_CCPCCPCCP', label: 'net_CCPCCPCCP' },
+                { value: 'net_CCPCCPCCPCCP', label: 'net_CCPCCPCCPCCP' },
+                { value: 'anomaly_CPCPCP', label: 'anomaly_CPCPCP' },
+                { value: 'anomaly_CPCPCPCP', label: 'anomaly_CPCPCPCP' },
+                { value: 'anomaly_CPCPCPCPCP', label: 'anomaly_CPCPCPCPCP' },
+                { value: 'anomaly_CPCPCP128', label: 'anomaly_CPCPCP128' },
+                { value: 'anomaly_CPCPCPCP128', label: 'anomaly_CPCPCPCP128' },
+                { value: 'anomaly_CPCPCPCPCP128', label: 'anomaly_CPCPCPCPCP128' },
               ],
               help: "is the network architecture e.g. 'net_CPCPCP' or 'InceptionV3'",
             },

--- a/ui/src/components/TFOption.vue
+++ b/ui/src/components/TFOption.vue
@@ -354,8 +354,78 @@ export default {
           {
             label: 'Network architecture',
             field: 'network_architecture',
-            type: types.TEXT,
+            type: types.SELECT,
             options: {
+              dataset: [
+                {
+                  value: 'net_CPCP',
+                  label: 'net_CPCP',
+                },
+                {
+                  value: 'net_CPCPCP',
+                  label: 'net_CPCPCP',
+                },
+                {
+                  value: 'net_CPCPCPCP',
+                  label: 'net_CPCPCPCP',
+                },
+                {
+                  value: 'net_CCPCCP',
+                  label: 'net_CCPCCP',
+                },
+                {
+                  value: 'net_CCPCCPCCP',
+                  label: 'net_CCPCCPCCP',
+                },
+                {
+                  value: 'net_CCPCCPCCPCCP',
+                  label: 'net_CCPCCPCCPCCP',
+                },
+                {
+                  value: 'VGG16',
+                  label: 'VGG16',
+                },
+                {
+                  value: 'InceptionV3',
+                  label: 'InceptionV3',
+                },
+                {
+                  value: 'MobileNetV2',
+                  label: 'MobileNetV2',
+                },
+                {
+                  value: 'EfficientNetB0',
+                  label: 'EfficientNetB0',
+                },
+                {
+                  value: 'EfficientNetB1',
+                  label: 'EfficientNetB1',
+                },
+                {
+                  value: 'EfficientNetB2',
+                  label: 'EfficientNetB2',
+                },
+                {
+                  value: 'EfficientNetB3',
+                  label: 'EfficientNetB3',
+                },
+                {
+                  value: 'EfficientNetB4',
+                  label: 'EfficientNetB4',
+                },
+                {
+                  value: 'EfficientNetB5',
+                  label: 'EfficientNetB5',
+                },
+                {
+                  value: 'EfficientNetB6',
+                  label: 'EfficientNetB6',
+                },
+                {
+                  value: 'EfficientNetB7',
+                  label: 'EfficientNetB7',
+                },
+              ],
               help: "is the network architecture e.g. 'net_CPCPCP' or 'InceptionV3'",
             },
           },


### PR DESCRIPTION
Adding the dropdown menu in the AI setting popup's network architecture field in the Train Tab of SVTrain UI.
![image](https://github.com/com2u/SVTrain/assets/137166869/c2c10489-94b9-40a5-87ba-913c224923bc)

