### PR TITLE
SWT-1096 Tab Name for instance

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -30,6 +30,12 @@ export default {
     if (this.$store.state.app.user.username) {
       await this.initSocket()
     }
+    const ejectxInstanceNameRegex = /\/\/(.*?)\.ejectx\.de/
+    const match = document.URL.match(ejectxInstanceNameRegex)
+    if (match && match.length > 1) {
+      const ejectxInstanceName = match[1]
+      document.title = `${document.title}${ejectxInstanceName}`
+    }
   },
   watch: {
     // eslint-disable-next-line func-names

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -30,11 +30,11 @@ export default {
     if (this.$store.state.app.user.username) {
       await this.initSocket()
     }
-    const ejectxInstanceNameRegex = /\/\/(.*?)\.ejectx\.de/
-    const match = document.URL.match(ejectxInstanceNameRegex)
+    const ejectxInstanceNameRegex = /^(.*?)\.ejectx\.de/
+    const match = window.location.hostname.match(ejectxInstanceNameRegex)
     if (match && match.length > 1) {
       const ejectxInstanceName = match[1]
-      document.title = `${document.title}${ejectxInstanceName}`
+      window.document.title = `${window.document.title}${ejectxInstanceName}`
     }
   },
   watch: {

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -26,7 +26,7 @@ module.exports = {
       .plugin('html')
       .tap((args) => {
         // eslint-disable-next-line no-param-reassign
-        args[0].title = 'SVTrain'
+        args[0].title = 'Eject-X: '
         return args
       })
 


### PR DESCRIPTION
Note: In our local, we don't have the hostname ending with **ejectx.de**, so this is the reason we are getting the EjectX: after that no instance name.
![image](https://github.com/com2u/SVTrain/assets/137166869/bd72b1e0-0a2d-426e-be1c-3c45d294c5a2)
