### PR TITLE
SWT-485 fixing Folder Statistics is displayed with some GUI error

### DIFF
--- a/ui/src/components/StatisticPopup.vue
+++ b/ui/src/components/StatisticPopup.vue
@@ -21,6 +21,7 @@
           </div>
         </div>
         <statistic-table
+          v-if="statistic.table"
           v-bind:folder="dir"
           v-bind:table="statistic.table"
           :toggleDataDisplayFormat = "toggleDataDisplayFormat"/>
@@ -56,7 +57,7 @@ export default {
     currentFolder() {
       const { root } = this.$store.state.app.config
       if (root && this.dir) {
-        return this.dir.substring(root.length)
+        return this.dir
       }
       return ''
     },


### PR DESCRIPTION
when no table is present
![image](https://github.com/com2u/SVTrain/assets/137166869/5d4d0e9e-f104-4fc7-974d-5db63722a8f0)

when the table is present
![image](https://github.com/com2u/SVTrain/assets/137166869/3f9aff70-0443-45c6-83c7-36e5277d92c4)
